### PR TITLE
Add a new "anno" (annotation) field for vast.SysCall

### DIFF
--- a/pyverilog/vparser/ast.py
+++ b/pyverilog/vparser/ast.py
@@ -1204,10 +1204,11 @@ class GenerateStatement(Node):
 class SystemCall(Node):
     attr_names = ('syscall',)
 
-    def __init__(self, syscall, args, lineno=0):
+    def __init__(self, syscall, args, lineno=0, anno=None):
         self.lineno = lineno
         self.syscall = syscall
         self.args = args
+        self.anno = anno
 
     def children(self):
         nodelist = []


### PR DESCRIPTION
This is to support annotating certain $display with verilator tags.